### PR TITLE
Fix: Fixed Refresh Search Result Maintain

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,10 +3,20 @@ import { Select } from '@/components'
 import styles from './Header.module.scss'
 import { useNavigate } from 'react-router-dom'
 
-function Header({ searchParam, isChangeSearchParamSelectActive, isChangeSelectBoxItems }) {
+function Header({
+  searchParam,
+  isChangeSearchParamSelectActive,
+  isChangeSelectBoxItems,
+  updateFormCheck
+}) {
   const navigate = useNavigate();
   const moveToPrevPage = () => {
-    navigate('/');
+    if (updateFormCheck) {
+      const userConfirmed = window.confirm('수정중인 내용이 있습니다.\n 지금 뒤로가시면 저장되지 않습니다.\n 뒤로 가시겠습니까?');
+      if (userConfirmed) {
+        navigate('/');
+      }
+    } else navigate('/');
   }
   return (
     <header className={styles.header}>

--- a/src/components/UserForm/UserForm.tsx
+++ b/src/components/UserForm/UserForm.tsx
@@ -2,7 +2,14 @@ import React from 'react'
 import styles from './UserForm.module.scss';
 import { Button, Select, TextField } from '@/components';
 
-function UserForm({ userInfo, onChangeUserInfo, selectActive, isChangeSelectActive, isChangeSelectBoxItems, onClickedSaveButton }) {
+function UserForm({
+  userInfo,
+  onChangeUserInfo,
+  selectActive,
+  isChangeSelectActive,
+  isChangeSelectBoxItems,
+  onClickedSaveButton
+}) {
   const updateValidationCheck = () => {
     const { id, firstName, lastName, role, telephone, email } = userInfo;
 

--- a/src/pages/user.tsx
+++ b/src/pages/user.tsx
@@ -21,8 +21,8 @@ function UserPage() {
   ]);
 
   const [searchParam, setSearchParam] = useState({
-    page: 1,
-    role: '',
+    page: Number(sessionStorage.getItem('page')) || 1,
+    role: sessionStorage.getItem('role') || '',
     active: false,
   });
 
@@ -33,6 +33,7 @@ function UserPage() {
   const [userList, setUserList] = useState([]);
   const [userInfo, setUserInfo] = useState({ ...initialValue });
   const [selectActive, setSelectActive] = useState(false);
+  const [updateFormCheck, setUpdateFormCheck] = useState(false);
 
   const loadUserList = () => {
     getUserList(searchParam)
@@ -53,10 +54,19 @@ function UserPage() {
 
   const handleCellClicked = (params: CellClickedEvent) => {
     const field = params.data;
-    setUserInfo({ ...field });
+    if (updateFormCheck) {
+      const userConfirmed = window.confirm('수정중인 내용이 있습니다.\n지금 변경하시면 저장되지 않습니다.\n변경 하시겠습니까?');
+      if (userConfirmed) {
+        setUpdateFormCheck(false);
+        setUserInfo({ ...field });
+      }
+    } else setUserInfo({ ...field });
   };
 
   const onChangeUserInfo = (name: string, value: string) => {
+    if (!updateFormCheck) {
+      setUpdateFormCheck(true);
+    }
     setUserInfo((prev) => {
       return { ...prev, [name]: value };
     })
@@ -77,10 +87,15 @@ function UserPage() {
     });
   }
 
-  const isChangeCurrentPage = (value: number) => onChangeSearchParam('page', value);
+  const isChangeCurrentPage = (value: number) => {
+    onChangeSearchParam('page', value);
+    sessionStorage.setItem('page', String(value));
+  };
 
   const isChangeSearchParamRole = (name: string, value: string) => {
     if (searchParam.active) {
+      sessionStorage.setItem('role', value);
+      isChangeCurrentPage(1);
       onChangeSearchParam('role', value);
     }
     isChangeSearchParamSelectActive();
@@ -100,6 +115,7 @@ function UserPage() {
         searchParam={searchParam}
         isChangeSelectActive={isChangeSearchParamSelectActive}
         isChangeSelectBoxItems={isChangeSearchParamRole}
+        updateFormCheck={updateFormCheck}
       />
       <Grid
         rowData       = {userList}
@@ -123,7 +139,6 @@ function UserPage() {
         isChangeSelectActive={isChangeSelectActive}
         isChangeSelectBoxItems={isChangeSelectBoxItems}
         onClickedSaveButton={onClickedSaveButton}
-        // updateValidationCheck={updateValidationCheck}
       />
     </div>
   )


### PR DESCRIPTION
## ✅  작업 단위
---
- 수정 중 뒤로가기 및 데이터 변경 시 경고 출력
- 페이지 새로고침 시 검색 결과 그대로 적용되도록 변경
- 쿠키가 아닌 sessionStorage를 이용함 쿠키는 다른 창에서 여러개의 검색결과를 보는데 방해 할 수 있어서
